### PR TITLE
Remove nav bar set height and scroll overflow

### DIFF
--- a/styles/clean-modern.css
+++ b/styles/clean-modern.css
@@ -262,7 +262,6 @@ textarea:focus {
   backdrop-filter: var(--blur-filter-high);
   padding: 0 5px;
   max-height: 300px;
-  overflow-y: scroll;
   border-radius: 0 0 var(--corner-radius) var(--corner-radius);
 }
 #navigation #nav-toggle{
@@ -289,7 +288,6 @@ textarea:focus {
 }
 #navigation .nav-item{
   width: 120px;
-  height: 130px;
   box-shadow: var(--drop-shadow);
   font-size: 12pt;
   text-align: center;


### PR DESCRIPTION
Closes: #12 
Removing the set height for nav items allows them to only take up as much vertical space as they need.

Disabling `overflow-y:scroll` allows the right-click settings to display over the top of the nav bar, rather than creating a scroll within the ribbon.

Examples:
![image](https://user-images.githubusercontent.com/18708522/112770858-a5350280-9020-11eb-8ba4-bec1a80b9cc6.png)
![image](https://user-images.githubusercontent.com/18708522/112770863-abc37a00-9020-11eb-9bce-4374c7c12cb1.png)

